### PR TITLE
fix; Trap에서 Respawner로 생성된 개랑 고양이에 반응 못하던 문제 수정

### DIFF
--- a/Assets/Prefabs/Traps/Traps.prefab
+++ b/Assets/Prefabs/Traps/Traps.prefab
@@ -58,7 +58,7 @@ GameObject:
   - component: {fileID: 1373524456002222138}
   - component: {fileID: 1109525780423057499}
   - component: {fileID: 340196302714667175}
-  - component: {fileID: 8451514881813210554}
+  - component: {fileID: 448205393203638987}
   m_Layer: 0
   m_Name: Catnip
   m_TagString: Untagged
@@ -238,7 +238,7 @@ TilemapCollider2D:
   m_MaximumTileChangeCount: 1000
   m_ExtrusionFactor: 0
   m_UseDelaunayMesh: 0
---- !u!114 &8451514881813210554
+--- !u!114 &448205393203638987
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -247,11 +247,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 4437776854479948767}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c49d5b2a989ccac4e8f4add331f066f6, type: 3}
+  m_Script: {fileID: 11500000, guid: 12766fd8a4998e043b77b2e1ef76d6d2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  compareTag: Player
-  Player: {fileID: 0}
+  Player: {fileID: 2415254073650170630, guid: e65017ca773752744ba7c28a16d84341, type: 3}
 --- !u!1 &5263945949621706613
 GameObject:
   m_ObjectHideFlags: 0
@@ -263,8 +262,8 @@ GameObject:
   - component: {fileID: 1345189555906742899}
   - component: {fileID: 7465954166768703}
   - component: {fileID: 2373967216836714596}
-  - component: {fileID: 5694518411525111664}
   - component: {fileID: 2194353470471070698}
+  - component: {fileID: 7295899858016386577}
   m_Layer: 0
   m_Name: BallPool
   m_TagString: Untagged
@@ -408,20 +407,6 @@ TilemapRenderer:
   m_Mode: 0
   m_DetectChunkCullingBounds: 0
   m_MaskInteraction: 0
---- !u!114 &5694518411525111664
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5263945949621706613}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c49d5b2a989ccac4e8f4add331f066f6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  compareTag: Player
-  Player: {fileID: 0}
 --- !u!19719996 &2194353470471070698
 TilemapCollider2D:
   m_ObjectHideFlags: 0
@@ -458,3 +443,16 @@ TilemapCollider2D:
   m_MaximumTileChangeCount: 1000
   m_ExtrusionFactor: 0
   m_UseDelaunayMesh: 0
+--- !u!114 &7295899858016386577
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5263945949621706613}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a275fd7eff4f5194582b776a24b8bef7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Player: {fileID: 2415254073650170630, guid: e65017ca773752744ba7c28a16d84341, type: 3}

--- a/Assets/Scripts/GameObj/BallPool.cs
+++ b/Assets/Scripts/GameObj/BallPool.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BallPool : Trap
+{
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        //레이어 및 Tag 확인 - 중복 카운트 방지
+        if (collision.gameObject.layer == LayerMask.NameToLayer("Dog")
+            && collision.CompareTag("Player"))
+        {
+            collision.transform.position = initialPosition; //플레이어의 position을 Respawner의 포지션으로 변경
+        }
+        //개가 아니면 아무런 효과 없음
+    }
+}

--- a/Assets/Scripts/GameObj/BallPool.cs.meta
+++ b/Assets/Scripts/GameObj/BallPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a275fd7eff4f5194582b776a24b8bef7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameObj/Catnip.cs
+++ b/Assets/Scripts/GameObj/Catnip.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Catnip : Trap
+{    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        //레이어 및 Tag 확인 - 중복 카운트 방지
+        if (collision.gameObject.layer == LayerMask.NameToLayer("Cat")
+            && collision.CompareTag("Player"))
+        {
+            collision.transform.position = initialPosition; //플레이어의 position을 Respawner의 포지션으로 변경
+        }
+        //고양이가 아니면 아무런 효과 없음
+    }
+}

--- a/Assets/Scripts/GameObj/Catnip.cs.meta
+++ b/Assets/Scripts/GameObj/Catnip.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12766fd8a4998e043b77b2e1ef76d6d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameObj/Trap.cs
+++ b/Assets/Scripts/GameObj/Trap.cs
@@ -5,33 +5,12 @@ using UnityEngine;
 
 public class Trap : MonoBehaviour
 {
-    [Header("비교할 태그")] public string compareTag;
-    public GameObject Player;
-    private Vector3 initialPosition; //초기 게임 오브젝트의 위치 (개/고양이/상자 등)
+    [SerializeField] private GameObject Player; //Respawner를 집어넣어서, 해당 위치에 Player가 다시 소환되도록 할 것임
+    protected Vector3 initialPosition; //초기 게임 오브젝트의 위치 (개/고양이/상자 등)
 
     private void Start()
     {
         //각 플레이어의 포지션 초기값 세팅
-        initialPosition = Player.transform.position;    
+        initialPosition = Player.transform.position;
     }
-
-
-    public string GetTargetTagName()
-    {
-        return compareTag;
-    }
-
-    private void OnTriggerEnter2D(Collider2D collision)
-    {
-        GetTargetTagName();
-        if (collision.CompareTag(compareTag))
-        {
-            //오브젝트의 TargetName과 부딪힌 Player의 태그비교
-            //개가 부딪혔다면 개, 고양이가 부딪혔다면 고양이가 초기위치로 감
-            //이를 활용하면, 이후 추락해서 사라져버리거나 원위치 시킬 수 없는 오브젝트도 원래 자리에 옮길 수 있음
-            Player.transform.position = initialPosition;
-           
-        }
-    }
-
 }


### PR DESCRIPTION
Trap.cs에서 Respawner로 생성된 개와 고양이 오브젝트를 판단하지 못하는 상태를 수정함. (Player가 스폰될 위치를 Respawner로 받고, Ballpool.cs와 Catnip.cs에서 각각 자신에게 맞는 오브젝트 판단)